### PR TITLE
Style report cards with strengths/weaknesses tags

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,49 @@
     renderCreators(); envPill.textContent='Mode: Airtable'; show('creators');
   }
 
-  function field(row, key){ return row[key] ?? row[key?.toLowerCase?.()] ?? ''; }
+  function extractValue(value, {forDisplay=false}={}){
+    if(value===undefined||value===null) return forDisplay?'':value;
+    if(Array.isArray(value)){
+      if(!forDisplay) return value;
+      return value.map(v=>extractValue(v,{forDisplay:true})).filter(v=>v!==undefined&&v!==null&&v!=='').join(', ');
+    }
+    if(typeof value==='object'){
+      if('value' in value) return extractValue(value.value,{forDisplay});
+      if(forDisplay){
+        if('name' in value) return extractValue(value.name,{forDisplay:true});
+        if('text' in value) return extractValue(value.text,{forDisplay:true});
+        if('label' in value) return extractValue(value.label,{forDisplay:true});
+        return '';
+      }
+      return value;
+    }
+    return value;
+  }
+
+  function field(row, key){
+    const raw = row?.[key] ?? row?.[key?.toLowerCase?.()];
+    if(raw===undefined||raw===null) return '';
+    return raw;
+  }
+
+  function displayField(row, key){
+    const raw = row?.[key] ?? row?.[key?.toLowerCase?.()];
+    const val = extractValue(raw,{forDisplay:true});
+    if(val===undefined||val===null) return '';
+    return String(val);
+  }
+
+  function deriveKeyAndLabel(rawValue, preferredLabel=''){
+    let key='';
+    if(preferredLabel) key=preferredLabel;
+    else if(Array.isArray(rawValue)) key=rawValue.map(x=>String(x??'')).join(', ');
+    else if(rawValue&&typeof rawValue==='object'){
+      try{ key=JSON.stringify(rawValue); }
+      catch(_err){ key=''; }
+    }else key = rawValue===undefined||rawValue===null?'':String(rawValue);
+    const label=preferredLabel || key || '—';
+    return {key,label};
+  }
 
   function keyFields(){ const f=cfg.fields; return {
     creatorId:f.creator.id, first:f.creator.first,last:f.creator.last,artist:f.creator.artist,email:f.creator.email,
@@ -73,10 +115,10 @@
       const creatorRecId = normalizeId(c.id);
       const count = counts[creatorRecId] || 0;
       const tr=el('tr',{},
-        el('td',{}, field(c,F.first)),
-        el('td',{}, field(c,F.last)),
-        el('td',{}, field(c,F.artist)),
-        el('td',{}, field(c,F.email)),
+        el('td',{}, displayField(c,F.first)),
+        el('td',{}, displayField(c,F.last)),
+        el('td',{}, displayField(c,F.artist)),
+        el('td',{}, displayField(c,F.email)),
         el('td',{class:'num'}, String(count))
       );
       tr.addEventListener('click', ()=> openProfile(c));
@@ -106,8 +148,8 @@
     requestsList.innerHTML='';
     reqs.forEach(r=>{
       const card=el('div',{class:'req'},
-        el('div',{}, el('div',{class:'meta'}, formatDate(field(r,F.reqDate))), el('div',{}, `${field(r,F.reqTitle)} — ${field(r,F.reqStage)}`)),
-        el('div',{class:'meta'}, field(state.currentCreator,F.artist))
+        el('div',{}, el('div',{class:'meta'}, formatDate(field(r,F.reqDate))), el('div',{}, `${displayField(r,F.reqTitle)} — ${displayField(r,F.reqStage)}`)),
+        el('div',{class:'meta'}, displayField(state.currentCreator,F.artist))
       );
       card.addEventListener('click', ()=> openRequest(r));
       requestsList.append(card);
@@ -119,10 +161,10 @@
     state.currentRequest=request; const F=keyFields();
     const headerSpec=[
       {label:'Submitted', value: formatDate(field(request,F.reqDate))},
-      {label:'Artist', value: field(state.currentCreator,F.artist)},
-      {label:'Track title', value: field(request,F.reqTitle)},
-      {label:'Track stage', value: field(request,F.reqStage)},
-      {label:'Email', value: field(state.currentCreator,F.email)},
+      {label:'Artist', value: displayField(state.currentCreator,F.artist)},
+      {label:'Track title', value: displayField(request,F.reqTitle)},
+      {label:'Track stage', value: displayField(request,F.reqStage)},
+      {label:'Email', value: displayField(state.currentCreator,F.email)},
     ];
     requestHeader.innerHTML=headerSpec.map(h=>`<div class="field"><div class="label">${h.label}</div><div class="value">${h.value||'—'}</div></div>`).join('');
 
@@ -135,33 +177,56 @@
 
   function renderChart(reports){
     const F=keyFields();
-    const labels=reports.map(r=>field(r,F.repCategory));
+    const catMeta=reports.map(rep=>{
+      const catRaw=field(rep,F.repCategory);
+      const catLabel=displayField(rep,F.repCategory);
+      return deriveKeyAndLabel(catRaw, catLabel);
+    });
+    const labels=catMeta.map(c=>c.label);
     const actual=reports.map(r=>Number(field(r,F.repActual))||0);
     const potential=reports.map(r=>Number(field(r,F.repPotential))||0);
     if(state.chart) state.chart.destroy();
-    state.chart=new Chart($('#scoresChart'),{type:'bar',data:{labels,datasets:[{label:'Actual',data:actual,borderWidth:1},{label:'Potential',data:potential,borderWidth:1}]},options:{responsive:true,indexAxis:'y',scales:{x:{suggestedMin:0,suggestedMax:5,ticks:{stepSize:0.5}}},plugins:{legend:{display:true,position:'top'}},onClick:(evt,els)=>{if(els&&els.length){const cat=labels[els[0].index]; focusReportByCategory(cat);}}}});
+    state.chart=new Chart($('#scoresChart'),{type:'bar',data:{labels,datasets:[{label:'Actual',data:actual,borderWidth:1},{label:'Potential',data:potential,borderWidth:1}]},options:{responsive:true,indexAxis:'y',scales:{x:{suggestedMin:0,suggestedMax:5,ticks:{stepSize:0.5}}},plugins:{legend:{display:true,position:'top'}},onClick:(evt,els)=>{if(els&&els.length){const idx=els[0].index; const cat=catMeta[idx]?.key ?? ''; focusReportByCategory(cat);}}}});
   }
 
   function renderReportCards(reports){
     const F=keyFields(); reportsRight.innerHTML='';
     reports.forEach(rep=>{
-      const cat=field(rep,F.repCategory);
-      const card=el('div',{class:'report-card','data-cat':cat},
-        el('div',{class:'tag'},cat),
-        el('div',{},`Calibre<br>${field(rep,F.repCalibre)||'—'}`),
-        el('div',{},`Raw feedback${field(rep,F.repRaw)||'—'}`),
-        el('div',{},`Strengths${field(rep,F.repStr)||'—'}`),
-        el('div',{},`Opportunities${field(rep,F.repOpp)||'—'}`),
+      const catRaw=field(rep,F.repCategory);
+      const catLabel=displayField(rep,F.repCategory);
+      const {key:catKey,label:tagText}=deriveKeyAndLabel(catRaw, catLabel);
+      const calibreText=displayField(rep,F.repCalibre)||'—';
+      const rawFeedback=displayField(rep,F.repRaw)||'—';
+      const strengthsText=displayField(rep,F.repStr)||'—';
+      const weaknessesText=displayField(rep,F.repOpp)||'—';
+      const card=el('div',{class:'report-card','data-cat':catKey},
+        el('div',{class:'tag'},tagText),
+        el('div',{class:'report-field report-calibre'},
+          el('span',{class:'field-label'},'Calibre'),
+          el('span',{class:'field-value'}, calibreText)
+        ),
+        el('div',{class:'report-field report-raw'},
+          el('span',{class:'field-label'},'Raw feedback'),
+          el('span',{class:'field-value'}, rawFeedback)
+        ),
+        el('div',{class:'report-note strengths'},
+          el('span',{class:'note-tag'},'Strengths'),
+          el('span',{class:'note-text'}, strengthsText)
+        ),
+        el('div',{class:'report-note weaknesses'},
+          el('span',{class:'note-tag'},'Weaknesses'),
+          el('span',{class:'note-text'}, weaknessesText)
+        ),
         el('div',{class:'actions-row',id:`actions-${field(rep,F.repId)}`})
       );
-      card.addEventListener('click',()=>focusReportByCategory(cat));
+      card.addEventListener('click',()=>focusReportByCategory(catKey));
       reportsRight.append(card);
       // Buttons from Actions
       const actions = state.actions.filter(a=> getLinkedIds(field(a,F.actRepLink)).includes(normalizeId(rep.id)) );
       const row=card.querySelector('.actions-row');
       if(!actions.length) row.append(el('span',{class:'meta'},'No actions'));
       actions.forEach(a=>{
-        const btn=el('button',{class:'btn'}, field(a,F.actAnchor)||'Action');
+        const btn=el('button',{class:'btn'}, displayField(a,F.actAnchor)||'Action');
         btn.addEventListener('click',(ev)=>{ev.stopPropagation(); openActionsAside(a.id, rep.id);});
         row.append(btn);
       });
@@ -184,10 +249,10 @@
       const isSelected = normalizeId(a.id)===normalizeId(selectedActionId);
       const card=el('div',{class:'action-card '+(isSelected?'':'collapsed')},
         el('div',{class:'header'},
-          el('div',{}, el('div',{class:'category'}, ''+ (field(a,F.actCategory)||'')), el('div',{class:'anchor'}, field(a,F.actAnchor)||'Action') ),
+          el('div',{}, el('div',{class:'category'}, ''+ (displayField(a,F.actCategory)||'')), el('div',{class:'anchor'}, displayField(a,F.actAnchor)||'Action') ),
           el('button',{class:'btn'}, isSelected?'Collapse':'Expand')
         ),
-        el('div',{class:'body'}, field(a,F.actDetails)||'')
+        el('div',{class:'body'}, displayField(a,F.actDetails)||'')
       );
       const toggle=card.querySelector('button');
       toggle.addEventListener('click',()=>{card.classList.toggle('collapsed'); toggle.textContent=card.classList.contains('collapsed')?'Expand':'Collapse';});

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,16 @@ main{padding:24px;max-width:1100px;margin:0 auto}h2{font-size:26px;margin:10px 0
 .request-header .label{color:var(--muted);font-size:12px;margin-bottom:4px}.request-header .value{font-weight:600}
 .report-layout{display:grid;grid-template-columns:1fr 1fr;gap:16px}.chart-card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:16px}
 .reports-right{display:flex;flex-direction:column;gap:12px}.report-card{background:var(--card);border:1px solid var(--line);border-radius:5px;padding:14px}
-.report-card.active{outline:2px solid #0D4F95}.report-card .tag{display:inline-block;background:#AECBEB;border:1px solid #0D4F95;color:#000;padding:6px 10px;border-radius:999px;font-size:12px;margin-bottom:8px}
+.report-card.active{outline:2px solid #0D4F95}.report-card .tag{display:inline-block;background:#AECBEB;border:1px solid #0D4F95;color:#000;padding:6px 10px;border-radius:999px;font-size:12px;margin-bottom:12px}
+.report-card .report-field{display:flex;flex-direction:column;gap:4px;margin-bottom:12px}
+.report-card .report-field .field-label{font-size:11px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:var(--muted)}
+.report-card .report-field .field-value{font-size:15px;line-height:1.5;color:var(--ink)}
+.report-card .report-field.report-raw .field-value{font-size:16px}
+.report-card .report-note{display:flex;gap:8px;align-items:flex-start;margin-top:10px}
+.report-card .report-note .note-tag{display:inline-flex;align-items:center;justify-content:center;padding:3px 12px;border-radius:999px;font-size:11px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:#fff;background:#0D4F95}
+.report-card .report-note.strengths .note-tag{background:#2E7D32}
+.report-card .report-note.weaknesses .note-tag{background:#C62828}
+.report-card .report-note .note-text{font-size:13px;line-height:1.5;color:var(--ink)}
 .report-card .actions-row{margin-top:12px;display:flex;flex-wrap:wrap;gap:8px}.btn{background:var(--chip);color:var(--ink);border:1px solid var(--line);padding:9px 12px;border-radius:999px;cursor:pointer}
 .actions-aside{position:fixed;top:64px;right:-420px;width:380px;bottom:48px;background:var(--card);border-left:1px solid var(--line);box-shadow:var(--shadow);border-top-left-radius:5px;border-bottom-left-radius:5px;transition:right .25s ease;display:flex;flex-direction:column}
 .actions-aside.open{right:0}.aside-header{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-bottom:1px solid var(--line)}


### PR DESCRIPTION
## Summary
- restructure report card markup to separate calibre, raw feedback, strengths, and weaknesses sections
- add labeled strengths/weaknesses tags backed by opportunities data for clarity when scanning cards
- style the new report sections so strengths/weaknesses text is smaller while raw notes remain prominent

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd9455fe40832eb1a4005234a5378e