### PR TITLE
Support inline playback of track attachments

### DIFF
--- a/app.js
+++ b/app.js
@@ -200,15 +200,27 @@
     const trackFileRaw=field(request,F.reqTrackFile);
     const trackFiles=Array.isArray(trackFileRaw)?trackFileRaw.filter(Boolean):(trackFileRaw?[trackFileRaw]:[]);
 
-    const trackFileNodes=trackFiles.map(file=>{
+    const buildTrackFileNode=(file)=>{
       const candidate=file?.url || file?.value || (typeof file==='string'?file:'');
       const url=candidate?String(candidate).trim():'';
       if(!url) return null;
-      const audio=el('audio',{controls:'',preload:'none'});
-      audio.src=url;
-      if(file?.filename) audio.title=file.filename;
-      return audio;
-    }).filter(Boolean);
+
+      const mime=(file?.type || file?.mimeType || '').toLowerCase();
+      const filename=file?.filename || file?.name || '';
+
+      if(mime.startsWith('audio/') || (!mime && url.match(/\.(mp3|wav|aac|m4a)$/i))){
+        const audio=el('audio',{controls:'',preload:'none'});
+        audio.src=url;
+        if(filename) audio.title=filename;
+        return audio;
+      }
+
+      const link=el('a',{href:url,target:'_blank',rel:'noopener noreferrer'});
+      link.textContent=filename || url;
+      return link;
+    };
+
+    const trackFileNodes=trackFiles.map(buildTrackFileNode).filter(Boolean);
 
     const headerSpec=[
       {label:'Submitted', text: formatDate(field(request,F.reqDate))},


### PR DESCRIPTION
## Summary
- add logic to derive playback nodes for request track attachments
- fall back to a download link when the attachment is not an audio file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbb94dee8832e9e864f6f48e46fa6